### PR TITLE
fix(code): improve code block readability across light and dark themes

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -54,7 +54,6 @@ nav{display:flex;gap:.5rem;margin:1.5rem 0}nav a{flex:1;display:flex;flex-direct
     html.light a.active,html.light a:active,html.light a:hover{color:oklch(0.53 0.2687 324.53) }
     html.light p,html.light ul,html.light ol, html.light .desc {color:oklch(0.4 0.1082 58.76) }
     html.light blockquote,html.light pre,html.light code,html.light article>img,html.light article>p>img,html.light .g img{background:oklch(0.94 0.1 93.24)}
-    html.light code{color:#000}
     html.dark{background:#000;--tc:#000;color:#fff}
     html.dark a{color:oklch(0.87 0.24 165.59)}
     html.dark a:visited{color:oklch(0.79 0.13 297.29)}
@@ -62,7 +61,6 @@ nav{display:flex;gap:.5rem;margin:1.5rem 0}nav a{flex:1;display:flex;flex-direct
     html.dark p,html.dark ul,html.dark ol, html.dark .desc {color:  oklch(0.92 0.15 94.86)}
     html.dark img[src$=".svg"],html.dark nav svg,html.dark .theme svg,html.dark footer svg{filter:invert(1)}
     html.dark blockquote,html.dark pre,html.dark code,html.dark article>img,html.dark article>p>img,html.dark .g img{background:#222}
-    html.dark code{color:#fff}
     a.active,a:active,a:hover{text-decoration-style:wavy}
     .tags a{text-decoration-style:dotted}
     hr{border:0;border-top:1px dashed;clear:both;margin-bottom:1.5rem}


### PR DESCRIPTION
Zola syntax highlighting is generated at build time and does not change when the UI theme is toggled at runtime.

When a dark highlight theme is used in light mode, or a light highlight theme is used in dark mode, code blocks can become hard to read due to insufficient contrast.

This change ensures code blocks remain readable across all light/dark theme combinations.