### PR TITLE
Allow copyright message customization

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -96,7 +96,7 @@ hr{border:0;border-top:1px dashed;clear:both;margin-bottom:1.5rem}
     </main>
     <hr>
     <footer class="s">
-        <span>© {{ config.title }} {{ now() | date(format="%Y") }}</span>
+        {% block footer_copyright %}<span>© {{ config.title }} {{ now() | date(format="%Y") }}</span>{% endblock %}
         {% if config.generate_feeds %}<span>{% if config.extra.inline_icons %}{{ icons::icon(name="rss.svg") }}{% else %}<img src="/icons/rss.svg" alt="">{% endif %} Feeds: <a href="{{ get_url(path='atom.xml',trailing_slash=false)|safe }}">Atom</a> · <a href="{{ get_url(path='rss.xml',trailing_slash=false)|safe }}">RSS</a></span>{% endif %}
     </footer>
     {% block body_end -%}


### PR DESCRIPTION
I'm using this theme (loving it btw :heart:) and I wanted to get rid of the copyright message in the footer, which forced me to copy-paste the entire `base.html`. So I figured it would be a bit more elegant if it was wrapped it in a block for added customizability, if you feel that's OK.